### PR TITLE
implementedthe ability to create time-bound payment streams, fund the m initially, and add additional funds during the stream’s lifecycle.

### DIFF
--- a/contracts/STXStream.clar
+++ b/contracts/STXStream.clar
@@ -1,15 +1,94 @@
 
 ;; STXStream
-;; <add a description here>
 
-;; constants
-;;
+;; error codes
+(define-constant ERR_UNAUTHORIZED (err u0))
+(define-constant ERR_INVALID_SIGNATURE (err u1))
+(define-constant ERR_STREAM_STILL_ACTIVE (err u2))
+(define-constant ERR_INVALID_STREAM_ID (err u3))
 
-;; data maps and vars
-;;
+;; data vars
+(define-data-var latest-stream-id uint u0)
 
-;; private functions
-;;
+;; streams mapping
+(define-map streams 
+    uint ;; stream-id
+    {
+        sender: principal,
+        recipient: principal,
+        balance: uint,
+        withdrawn-balance: uint,
+        payment-per-block: uint,
+        timeframe: (tuple (start-block uint) (stop-block uint))
+    }
+)
 
-;; public functions
-;;
+;; Create a new stream
+(define-public (stream-to
+    (recipient principal)
+    (initial-balance uint)
+    (timeframe (tuple (start-block uint) (stop-block uint)))
+    (payment-per-block uint)
+   )
+    (let (
+       (stream {
+            sender: contract-caller,
+            recipient: recipient,
+            balance: initial-balance,
+            withdrawn-balance: u0,
+            payment-per-block: payment-per-block,
+            timeframe: timeframe
+        })
+        (current-stream-id (var-get latest-stream-id))
+    )
+        ;; stx-transfer takes in (amount, sender, recipient) arguments
+        ;; for the `recipient` - we do `(as-contract tx-sender)`
+        ;; `as-contract` switches the `tx-sender` variable to be the contract principal
+        ;; inside it's scope
+        ;; so doing `as-contract tx-sender` gives us the contract address itself
+        ;; this is like doing address(this) in Solidity
+
+        (try! (stx-transfer? initial-balance contract-caller (as-contract tx-sender)))
+        (map-set streams current-stream-id stream)
+        (var-set latest-stream-id (+ current-stream-id u1))
+        (ok current-stream-id)
+    )
+)
+
+;; Increase the locked STX balance for a stream 
+(define-public (refuel (stream-id uint) (amount uint))
+    (let (
+        (stream (unwrap! (map-get? streams stream-id) ERR_INVALID_STREAM_ID))
+    )
+    (asserts! (is-eq contract-caller (get sender stream)) ERR_UNAUTHORIZED)
+    (try! (stx-transfer? amount contract-caller (as-contract tx-sender)))
+    (map-set streams stream-id
+        (merge stream {balance: (+ (get balance stream) amount)})
+    )
+    (ok amount)
+    )
+)
+
+;; Calculate the number of blocks a stream has been active
+(define-read-only (calculate-block-delta (timeframe (tuple (start-block uint) (stop-block uint))))
+    (let (
+        (start-block (get start-block timeframe))
+        (stop-block (get stop-block timeframe))
+
+        (delta
+            (if (<= stacks-block-height start-block)
+                ;; then
+                u0 
+                ;; else
+                (if (< stacks-block-height stop-block)
+                    ;; then
+                    (- stacks-block-height start-block)
+                    ;; else
+                    (- stop-block start-block)
+                )
+            )
+        )
+    )
+    delta
+    )
+)


### PR DESCRIPTION
# Pull Request: Implement Streaming Payment Core Functions in Clarity Contract

## Summary

This pull request introduces core functionality for a **Streaming Payment** smart contract on the Stacks blockchain. It implements the ability to create time-bound payment streams, fund them initially, and add additional funds during the stream’s lifecycle.

---

## Changes

### 1. Error Code Definitions

* Added standardized error constants for:

  * Unauthorized access (`ERR_UNAUTHORIZED`)
  * Invalid signatures (`ERR_INVALID_SIGNATURE`)
  * Attempting to refund or withdraw from an active stream (`ERR_STREAM_STILL_ACTIVE`)
  * Invalid stream IDs (`ERR_INVALID_STREAM_ID`)

### 2. State Variables and Mappings

* Introduced a `latest-stream-id` data variable to keep track of stream IDs incrementally.
* Added a `streams` map storing stream details keyed by stream ID. Each stream record includes:

  * `sender`: Principal funding the stream
  * `recipient`: Principal receiving funds
  * `balance`: Total locked STX
  * `withdrawn-balance`: Amount already withdrawn
  * `payment-per-block`: STX paid per block
  * `timeframe`: Tuple with `start-block` and `stop-block` indicating the stream duration

### 3. Public Functions

#### `stream-to`

* Allows a sender (contract caller) to create a new payment stream to a recipient.
* Locks an initial STX balance into the contract using `stx-transfer?`.
* Stores the stream details in the `streams` map.
* Increments the global `latest-stream-id` for unique identification.
* Returns the newly assigned stream ID.

#### `refuel`

* Enables the sender to add additional locked STX to an existing stream.
* Validates the stream ID exists and the caller is the stream’s sender.
* Transfers the additional amount into the contract.
* Updates the stream’s locked balance accordingly.
* Returns the amount added on success.

### 4. Read-Only Functions

#### `calculate-block-delta`

* Calculates the number of blocks that have elapsed within the stream’s timeframe.
* Returns zero if the current block height is before the start block.
* Returns the difference between current block and start block if within timeframe.
* Returns the total duration if the current block height exceeds the stop block.

---

## Motivation

Streaming payments are a powerful primitive for continuous and trust-minimized transfer of funds over time. This PR lays the foundation to support:

* Time-based locked payments with withdrawal and refund capabilities.
* Incremental deposits to streams allowing flexible top-ups.
* Accurate balance calculations dependent on blockchain height.

---

## Testing & Validation

* Transferring STX into the contract is verified via `stx-transfer?`.
* Access control checks enforce only the sender can refuel.
* Stream ID validation protects against invalid lookups.
* Timeframe calculation logic ensures correct block delta for payments.

---
