### PR TITLE
 added critical functionality for withdrawing funds, refunding excess locked STX

### DIFF
--- a/contracts/STXStream.clar
+++ b/contracts/STXStream.clar
@@ -92,3 +92,104 @@
     delta
     )
 )
+
+
+;; Check balance for a party involved in a stream
+(define-read-only (balance-of (stream-id uint) (who principal))
+    (let (
+        (stream (unwrap! (map-get? streams stream-id) u0))
+        (block-delta (calculate-block-delta (get timeframe stream)))
+        (recipient-balance (* block-delta (get payment-per-block stream)))
+    )
+    (if (is-eq who (get recipient stream))
+        (- recipient-balance (get withdrawn-balance stream))
+        (if (is-eq who (get sender stream))
+            (- (get balance stream) recipient-balance)
+            u0
+            )
+        )
+    )
+)
+
+;; Withdraw received tokens
+(define-public (withdraw (stream-id uint))
+    (let (
+        (stream (unwrap! (map-get? streams stream-id) ERR_INVALID_STREAM_ID))
+        (balance (balance-of stream-id contract-caller))
+    )
+        (asserts! (is-eq contract-caller (get recipient stream)) ERR_UNAUTHORIZED)
+        (map-set streams stream-id
+            (merge stream {withdrawn-balance: (+ (get withdrawn-balance stream) balance)})
+        )
+        (try! (as-contract (stx-transfer? balance tx-sender (get recipient stream))))
+        (ok balance)
+     )
+)
+
+;; Withdraw excess locked tokens
+(define-public (refund
+    (stream-id uint)
+  )
+  (let (
+    (stream (unwrap! (map-get? streams stream-id) ERR_INVALID_STREAM_ID))
+    (balance (balance-of stream-id (get sender stream)))
+  )
+    (asserts! (is-eq contract-caller (get sender stream)) ERR_UNAUTHORIZED)
+    (asserts! (< (get stop-block (get timeframe stream)) stacks-block-height) ERR_STREAM_STILL_ACTIVE)
+    (map-set streams stream-id (merge stream {
+        balance: (- (get balance stream) balance),
+      }
+    ))
+    (try! (as-contract (stx-transfer? balance tx-sender (get sender stream))))
+    (ok balance)
+  )
+)
+
+;; Get hash of stream
+(define-read-only (hash-stream
+    (stream-id uint)
+    (new-payment-per-block uint)
+    (new-timeframe (tuple (start-block uint) (stop-block uint)))
+  )
+  (let (
+    (stream (unwrap! (map-get? streams stream-id) (sha256 0)))
+    (msg (concat (concat (unwrap-panic (to-consensus-buff? stream)) (unwrap-panic (to-consensus-buff? new-payment-per-block))) (unwrap-panic (to-consensus-buff? new-timeframe))))
+  )
+    (sha256 msg)
+  )
+)
+
+;; Signature verification
+(define-read-only (validate-signature (hash (buff 32)) (signature (buff 65)) (signer principal))
+        (is-eq 
+          (principal-of? (unwrap! (secp256k1-recover? hash signature) false)) 
+          (ok signer)
+        )
+)
+
+;; Update stream configuration
+(define-public (update-details
+    (stream-id uint)
+    (payment-per-block uint)
+    (timeframe (tuple (start-block uint) (stop-block uint)))
+    (signer principal)
+    (signature (buff 65))
+  )
+  (let (
+    (stream (unwrap! (map-get? streams stream-id) ERR_INVALID_STREAM_ID))  
+  )
+    (asserts! (validate-signature (hash-stream stream-id payment-per-block timeframe) signature signer) ERR_INVALID_SIGNATURE)
+    (asserts!
+      (or
+        (and (is-eq (get sender stream) contract-caller) (is-eq (get recipient stream) signer))
+        (and (is-eq (get sender stream) signer) (is-eq (get recipient stream) contract-caller))
+      )
+      ERR_UNAUTHORIZED
+    )
+    (map-set streams stream-id (merge stream {
+        payment-per-block: payment-per-block,
+        timeframe: timeframe
+    }))
+    (ok true)
+  )
+)


### PR DESCRIPTION
Pull Request: Implement Withdrawal, Refund, and Stream Update Functions for STX Streaming Contract
Summary
This pull request adds critical functionality for withdrawing funds, refunding excess locked STX, and updating stream parameters with off-chain signature verification to the Stacks streaming payment contract. It complements earlier work on stream creation and refueling by enabling recipients to claim funds, senders to reclaim unused tokens, and both parties to securely update stream details.

Changes
1. Read-Only Functions
balance-of
Calculates the current withdrawable or refundable balance for a specified principal (who) in a given stream.

For recipients, it returns the accumulated payment based on elapsed blocks minus any previously withdrawn amount.

For senders, it returns the remaining locked balance minus the recipient’s accrued balance.

Returns zero for any unrelated principals.

hash-stream
Produces a SHA-256 hash representing the current stream state combined with proposed updates (new-payment-per-block, new-timeframe).

Used for off-chain signature verification to authorize stream detail changes.

validate-signature
Validates a secp256k1 signature on a given hash.

Checks that the recovered public key corresponds to the expected signer principal.

2. Public Functions
withdraw
Allows the recipient to withdraw all accrued tokens available to them in the stream.

Validates caller identity as recipient.

Updates the withdrawn balance on the stream.

Transfers the STX tokens to the recipient.

Returns the withdrawn amount on success.

refund
Enables the sender to reclaim locked STX tokens that were not paid out after the stream has ended.

Validates caller identity as sender.

Ensures the stream’s stop block is in the past (stream expired).

Deducts refunded tokens from the locked balance.

Transfers the refundable tokens back to the sender.

Returns the refunded amount on success.

update-details
Allows either sender or recipient to update payment-per-block and timeframe parameters of a stream.

Requires a valid off-chain secp256k1 signature from the counterparty (not the caller).

Confirms that either the caller is sender and the signer is recipient, or vice versa.

Updates the stream record with new parameters upon successful verification.

Returns true on success.

Motivation
This update completes the streaming payment lifecycle by enabling:

Recipients to claim earned payments securely and incrementally.

Senders to recover unused locked funds, preventing indefinite locking.

Both parties to cooperatively modify stream conditions with cryptographic consent.

The off-chain signature mechanism ensures trust-minimized updates without requiring both parties to interact on-chain simultaneously.